### PR TITLE
Add percentage difference to result set

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ const rembrandt = new Rembrandt({
 rembrandt.compare()
   .then(function (result) {
     console.log('Passed:', result.passed)
-    console.log('Difference:', (result.threshold * 100).toFixed(2), '%')
+    console.log('Pixel Difference:', result.differences, 'Percentage Difference', result.percentageDifference, '%')
     console.log('Composition image buffer:', result.compositionImage)
 
     // Note that `compositionImage` is an Image when Rembrandt.js is run in the browser environment

--- a/lib/image-comparator.js
+++ b/lib/image-comparator.js
@@ -60,8 +60,11 @@ export default class ImageComparator {
 
       // Calculate threshold for differences
       let threshold = differences
+
+      // Calculate percentage difference
+      const totalPixels = width * height
+      const percentageDifference = differences / totalPixels
       if (this._options.thresholdType === Constants.THRESHOLD_PERCENT) {
-        const totalPixels = width * height
         threshold = threshold / totalPixels
       }
 
@@ -72,10 +75,10 @@ export default class ImageComparator {
       if (this._options.renderComposition) {
         this._compositionImage.render()
           .then((image) => {
-            resolve({ differences, threshold, passed, compositionImage: image })
+            resolve({ differences, percentageDifference, threshold, passed, compositionImage: image })
           })
       } else {
-        resolve({ differences, threshold, passed })
+        resolve({ differences, percentageDifference, threshold, passed })
       }
     })
   }


### PR DESCRIPTION
Hi,

I noticed that there was an asymmetry in the result set. When I choose a percentage threshold I get the total pixel difference `{differences}` as well as the percentage difference `{threshold}`, whereas when I choose a pixel threshold these values are the same and I have no way to get at the percentage difference from the result set alone. So I added the field `percentageDifference` to the result set.